### PR TITLE
Bugfix to work with Composer 1.x & 2.x

### DIFF
--- a/zray/zray.php
+++ b/zray/zray.php
@@ -38,6 +38,14 @@ class Composer
 
         $json = file_get_contents($jsonFile);
         $data = json_decode($json);
+	
+	/*
+	 * Composer 1.x - output is already an array
+	 * Composer 2.x - output is an object; the array we want is in the 'packages' property
+	 */
+	if (is_object($data) && isset($data->packages)) {
+            $data = $data->packages;
+	}
 
         foreach ($data as $package) {
             $source = (isset($package->source) && isset($package->source->url))


### PR DESCRIPTION
Composer 2.x output is an object with a 'packages' array. Composer 1.x simply output an array of packages.

Currently using `Zend Server 9.1.10+b202` on `Ubuntu 16.04`

Using the default composer installation command in Docker installs the new 2.x version:
```
RUN /usr/local/zend/bin/php -r "readfile('https://getcomposer.org/installer');" | /usr/local/zend/bin/php \
    && /usr/local/zend/bin/php composer.phar self-update \
    && /usr/local/zend/bin/php composer.phar update
```

Launching ZS via the standard `/usr/local/bin/run` file results in the following errors:
```
Zend Server initialization result: success.
Zend Server is ready for use
Your application is available at http://172.17.0.2
To access Zend Server, navigate to http://172.17.0.2:10081
Your admin password is
Notice: Trying to get property of non-object in /usr/local/zend/var/plugins/composer/zray/zray.php on line 48
Notice: Trying to get property of non-object in /usr/local/zend/var/plugins/composer/zray/zray.php on line 49
Notice: Trying to get property of non-object in /usr/local/zend/var/plugins/composer/zray/zray.php on line 63
Notice: Trying to get property of non-object in /usr/local/zend/var/plugins/composer/zray/zray.php on line 48
Notice: Trying to get property of non-object in /usr/local/zend/var/plugins/composer/zray/zray.php on line 49
Notice: Trying to get property of non-object in /usr/local/zend/var/plugins/composer/zray/zray.php on line 63
a
/usr/local/bin/run: line 37: [: too many arguments
Adding Node Id to DB table for sigterm handler
Usage:
/usr/local/bin/nothing <mysql-hostname> <mysql-port> <mysql-username> <mysql-password> <mysql-db-name> <server-id> <web-api-key-name> <web-api-key>
```

Root cause is the JSON format of installed.json has changed and can no longer be parsed by the plugin.

1.x format:
```
[
     {
         "name": "aws/aws-sdk-php",
         "version": "2.8.31",
         "version_normalized": "2.8.31.0",
         "source": {
             "type": "git",
             "url": "https://github.com/aws/aws-sdk-php.git",
             "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68"
         },
```

2.x format:
```
{
     "packages": [
         {
             "name": "aws/aws-sdk-php",
             "version": "2.8.31",
             "version_normalized": "2.8.31.0",
             "source": {
                "type": "git",
                "url": "https://github.com/aws/aws-sdk-php.git",
                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68"
            },
```

A temporary workaround is to force version 1.x during install:
`&& /usr/local/zend/bin/php composer.phar self-update --1 \`
